### PR TITLE
55660 register total credits field missing from differing information on comparison page

### DIFF
--- a/Models/Constants.cs
+++ b/Models/Constants.cs
@@ -15,6 +15,7 @@
         public const string END_POINT_ASSESSMENT_STD = "End-point assessment standard";
         public const string AWARDING_ORG = "Awarding Organisation";
         public const string GRADING_TYPE = "Grading type";
+        public const string TOTAL_CREDITS = "Total credits";
         public const string SPECIALISMS = "Specialisms";
         public const string STATUS = "Status";
         public const string ENGLAND = "England";

--- a/UseCases/Qualifications/QualificationsUseCases.cs
+++ b/UseCases/Qualifications/QualificationsUseCases.cs
@@ -38,6 +38,7 @@ namespace Ofqual.Common.RegisterFrontend.UseCases.Qualifications
             DiffValues($"{left.ApprenticeshipStandardTitle} ({left.ApprenticeshipStandardReferenceNumber})", $"{right.ApprenticeshipStandardTitle} ({right.ApprenticeshipStandardReferenceNumber})", END_POINT_ASSESSMENT_STD, ref differing);
             DiffValues(left.OrganisationName, right.OrganisationName, AWARDING_ORG, ref differing);
             DiffValues(left.GradingType, right.GradingType, GRADING_TYPE, ref differing);
+            DiffValues(left.TotalCredits.ToString(), right.TotalCredits.ToString(), TOTAL_CREDITS, ref differing);
             DiffValues(left.Specialism, right.Specialism, SPECIALISMS, ref differing);
             DiffValues(left.Status, right.Status, STATUS, ref differing);
 


### PR DESCRIPTION
add new const TOTAL_CREDITS 
add total credits to be compared to be added into the 'differing information' section